### PR TITLE
SourceInspector: ignore stylesheet urls within text content when finding stylesheet references

### DIFF
--- a/src/SourceInspector.php
+++ b/src/SourceInspector.php
@@ -146,6 +146,10 @@ class SourceInspector
             $hrefValueStartPosition
         );
 
+        if (null !== $hrefLinkPrefix && !$this->endsWithHrefAttribute($hrefLinkPrefix)) {
+            $hrefLinkPrefix = null;
+        }
+
         if (null === $hrefLinkPrefix) {
             return $this->findStylesheetUrlReference(
                 mb_substr($content, $hrefValueEndPosition, null, $encoding),
@@ -155,6 +159,13 @@ class SourceInspector
         }
 
         return $hrefLinkPrefix . $hrefValue;
+    }
+
+    private function endsWithHrefAttribute(string $hrefLinkPrefix)
+    {
+        $endsWithHrefEqualsPattern = '/href="?\'?$/';
+
+        return preg_match($endsWithHrefEqualsPattern, $hrefLinkPrefix) > 0;
     }
 
     private function findLinkElementHrefValues(WebPage $webPage): array

--- a/src/SourceInspector.php
+++ b/src/SourceInspector.php
@@ -146,7 +146,7 @@ class SourceInspector
             $hrefValueStartPosition
         );
 
-        if (null !== $hrefLinkPrefix && !$this->endsWithHrefAttribute($hrefLinkPrefix)) {
+        if (null !== $hrefLinkPrefix && !$this->isValidLinkHrefPrefix($hrefLinkPrefix, $encoding)) {
             $hrefLinkPrefix = null;
         }
 
@@ -161,11 +161,18 @@ class SourceInspector
         return $hrefLinkPrefix . $hrefValue;
     }
 
-    private function endsWithHrefAttribute(string $hrefLinkPrefix)
+    private function isValidLinkHrefPrefix(string $hrefLinkPrefix, string $encoding): bool
     {
-        $endsWithHrefEqualsPattern = '/href="?\'?$/';
+        if (!$this->containsOnlyOneLeftAngledCaret($hrefLinkPrefix, $encoding)) {
+            return false;
+        }
 
-        return preg_match($endsWithHrefEqualsPattern, $hrefLinkPrefix) > 0;
+        return true;
+    }
+
+    private function containsOnlyOneLeftAngledCaret(string $hrefLinkPrefix, string $encoding): bool
+    {
+        return 1 === mb_substr_count($hrefLinkPrefix, '<', $encoding);
     }
 
     private function findLinkElementHrefValues(WebPage $webPage): array

--- a/tests/Fixtures/Html/stylesheet-href-attribute-within-text-content.html
+++ b/tests/Fixtures/Html/stylesheet-href-attribute-within-text-content.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="/one.css">
+        <link rel="stylesheet" href="/two.css">
+    </head>
+
+    <body>
+        <div>
+            <span>href="/one.css"</span>
+        </div>
+    </body>
+</html>

--- a/tests/Fixtures/Html/stylesheet-url-within-text-content.html
+++ b/tests/Fixtures/Html/stylesheet-url-within-text-content.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="/style.css">
+    </head>
+
+    <body>
+        <div>
+            <link rel="alternate" type="application/atom+xml" title="" href="/">
+            <span>theme=/style.css</span>
+        </div>
+    </body>
+</html>

--- a/tests/SourceInspectorTest.php
+++ b/tests/SourceInspectorTest.php
@@ -458,6 +458,15 @@ class SourceInspectorTest extends \PHPUnit\Framework\TestCase
                     '<link' . "\n            " . 'href="/style.css',
                 ],
             ],
+            'stylesheet url within text content' => [
+                'webPage' => WebPageFactory::create(
+                    FixtureLoader::load('Html/stylesheet-url-within-text-content.html'),
+                    new Uri('http://example.com/')
+                ),
+                'expectedStylesheetUrlReferences' => [
+                    '<link rel="stylesheet" href="/style.css',
+                ],
+            ],
         ];
     }
 

--- a/tests/SourceInspectorTest.php
+++ b/tests/SourceInspectorTest.php
@@ -467,6 +467,59 @@ class SourceInspectorTest extends \PHPUnit\Framework\TestCase
                     '<link rel="stylesheet" href="/style.css',
                 ],
             ],
+            'stylesheet url within text content; invalid link href prefix ends with href attribute, no quotation' => [
+                'webPage' => WebPageFactory::create(
+                    str_replace(
+                        '<span>theme=/style.css</span>',
+                        '<span>href=/style.css</span>',
+                        FixtureLoader::load('Html/stylesheet-url-within-text-content.html')
+                    ),
+                    new Uri('http://example.com/')
+                ),
+                'expectedStylesheetUrlReferences' => [
+                    '<link rel="stylesheet" href="/style.css',
+                ],
+            ],
+            'stylesheet url within text content; invalid link href prefix ends with href attribute, single quoted' => [
+                'webPage' => WebPageFactory::create(
+                    str_replace(
+                        '<span>theme=/style.css</span>',
+                        '<span>href=\'/style.css</span>',
+                        FixtureLoader::load('Html/stylesheet-url-within-text-content.html')
+                    ),
+                    new Uri('http://example.com/')
+                ),
+                'expectedStylesheetUrlReferences' => [
+                    '<link rel="stylesheet" href="/style.css',
+                ],
+            ],
+            'stylesheet url within text content; invalid link href prefix ends with href attribute, double quoted' => [
+                'webPage' => WebPageFactory::create(
+                    str_replace(
+                        '<span>theme=/style.css</span>',
+                        '<span>href="/style.css</span>',
+                        FixtureLoader::load('Html/stylesheet-url-within-text-content.html')
+                    ),
+                    new Uri('http://example.com/')
+                ),
+                'expectedStylesheetUrlReferences' => [
+                    '<link rel="stylesheet" href="/style.css',
+                ],
+            ],
+            'stylesheet href attribute within text content' => [
+                'webPage' => WebPageFactory::create(
+                    str_replace(
+                        '',
+                        '',
+                        FixtureLoader::load('Html/stylesheet-href-attribute-within-text-content.html')
+                    ),
+                    new Uri('http://example.com/')
+                ),
+                'expectedStylesheetUrlReferences' => [
+                    '<link rel="stylesheet" href="/one.css',
+                    '<link rel="stylesheet" href="/two.css',
+                ],
+            ],
         ];
     }
 

--- a/tests/WrapperTest.php
+++ b/tests/WrapperTest.php
@@ -115,6 +115,7 @@ class WrapperTest extends \PHPUnit\Framework\TestCase
         $noStylesheetsHtml = FixtureLoader::load('Html/minimal-html5.html');
         $singleStylesheetHtml = FixtureLoader::load('Html/minimal-html5-single-stylesheet.html');
         $singleEmptyHrefStylesheetHtml = FixtureLoader::load('Html/minimal-html5-unavailable-stylesheet.html');
+        $cssUrlWithinTextContentHtml = FixtureLoader::load('Html/stylesheet-url-within-text-content.html');
         $cssNoMessagesPath = FixtureLoader::getPath('Css/valid-no-messages.css');
         $cssWithImportPath = FixtureLoader::getPath('Css/valid-with-import.css');
 
@@ -769,6 +770,59 @@ class WrapperTest extends \PHPUnit\Framework\TestCase
                 ],
                 'expectedWarningCount' => 0,
                 'expectedErrorCount' => 2,
+            ],
+            'stylesheet url with text content' => [
+                'sourceStorage' => $this->createSourceStorageWithValidateExpectationsFoo(
+                    new SourceMap(),
+                    $singleStylesheetValidNoMessagesSourceMap,
+                    [
+                        'http://example.com/style.css',
+                    ],
+                    new SourceMap([
+                        new Source('http://example.com/style.css', 'file:/tmp/valid-no-messages-hash.css'),
+                    ]),
+                    str_replace(
+                        [
+                            '<link rel="stylesheet" href="/style.css">',
+                        ],
+                        [
+                            '<link rel="stylesheet" href="file:/tmp/valid-no-messages-hash.css">',
+                        ],
+                        $cssUrlWithinTextContentHtml
+                    ),
+                    new SourceMap([
+                        new Source('http://example.com/style.css', 'file:/tmp/valid-no-messages-hash.css'),
+                    ]),
+                    new SourceMap([
+                        new Source('http://example.com/', 'file:/tmp/web-page-hash.html'),
+                        new Source('http://example.com/style.css', 'file:/tmp/valid-no-messages-hash.css'),
+                    ])
+                ),
+                'commandFactory' => $this->createCommandFactory([
+                    [
+                        'expectedUrl' => 'file:/tmp/web-page-hash.html',
+                        'expectedVendorExtensionSeverityLevel' => VendorExtensionSeverityLevel::LEVEL_WARN,
+                    ],
+                ]),
+                'commandExecutor' => $this->createCommandExecutor([
+                    [
+                        'output' => $this->createValidationOutput(
+                            'file:/tmp/web-page-hash.html',
+                            new MessageList()
+                        ),
+                        'expectedOutputParserConfiguration' => Flags::NONE,
+                        'expectedResourceUrl' => 'file:/tmp/web-page-hash.html',
+                    ],
+                ]),
+                'sourceMap' => $singleStylesheetValidNoMessagesSourceMap,
+                'sourceFixture' => $cssUrlWithinTextContentHtml,
+                'sourceUrl' => 'http://example.com/',
+                'vendorExtensionSeverityLevel' => VendorExtensionSeverityLevel::LEVEL_WARN,
+                'domainsToIgnore' => [],
+                'outputParserConfiguration' => Flags::NONE,
+                'expectedMessages' => [],
+                'expectedWarningCount' => 0,
+                'expectedErrorCount' => 0,
             ],
         ];
     }


### PR DESCRIPTION
Fixes #210